### PR TITLE
fix: add docker_entrypoint.sh

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "Running mysql"
+mysqld &
+
+echo "Running Labelbase"
+/app/run.sh &
+
+echo "Running nginx"
+nginx -g 'daemon off;'
+

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -19,7 +19,7 @@ assets:
 main:
   type: docker
   image: main
-  entrypoint: "/app/run.sh"
+  entrypoint: "docker_entrypoint.sh"
   args: []
   mounts:
     main: /root


### PR DESCRIPTION
# TODO

`No package matches 'mysql-devel'`

Fix this in the dockerfile and we're golden.

How the fuck do I install `libmysqlclient-dev` in fucking oracle linux?